### PR TITLE
fix(Util): use any custom protocol for outboundRE

### DIFF
--- a/packages/@vuepress/theme-default/util/index.js
+++ b/packages/@vuepress/theme-default/util/index.js
@@ -1,7 +1,7 @@
 export const hashRE = /#.*$/
 export const extRE = /\.(md|html)$/
 export const endingSlashRE = /\/$/
-export const outboundRE = /^(https?:|mailto:|tel:|[a-zA-Z]{4,}:)/
+export const outboundRE = /^[a-z]+:/i
 
 export function normalize (path) {
   return decodeURI(path)


### PR DESCRIPTION
Little improvement for https://github.com/vuejs/vuepress/pull/1677

I think we can use any custom protocol for external link.